### PR TITLE
Fix AppImage crash on native Wayland

### DIFF
--- a/deploy_linux.sh
+++ b/deploy_linux.sh
@@ -126,6 +126,11 @@ if [[ $create_package = true ]] ; then
   mkdir -p bin/usr/plugins/wayland-client
   cp $QT_ROOT_DIR/plugins/wayland-client/*.so bin/usr/plugins/wayland-client/
 
+  # linuxdeploy-plugin-qt doesn't deploy these, but the wayland platform plugin
+  # can't create an EGL/OpenGL surface without them and qFatals on startup
+  mkdir -p bin/usr/plugins/wayland-graphics-integration-client
+  cp $QT_ROOT_DIR/plugins/wayland-graphics-integration-client/*.so bin/usr/plugins/wayland-graphics-integration-client/
+
   cp $QT_ROOT_DIR/lib/libQt6WaylandClient.so* bin/usr/lib/
 
   echo '---- Running AppImage packager'


### PR DESCRIPTION
The AppImage aborts on startup on native Wayland because the `wayland-graphics-integration-client` plugins aren't bundled (linuxdeploy-plugin-qt doesn't deploy them, and `EXTRA_QT_PLUGINS` is deprecated and silently ignored). Qt then finds no client buffer integration and can't create an EGL context:

```
qt.qpa.wayland: Available client buffer integrations: QList()
Failed to initialize graphics backend for OpenGL.
```

Copy the plugin dir into the appdir, same as already done for `wayland-client`.