### PR TITLE
Fix game tile not resetting after removing a game

### DIFF
--- a/src/qml/GameItem.qml
+++ b/src/qml/GameItem.qml
@@ -23,6 +23,30 @@ Button {
         }
     }
 
+    function refreshInstalled() {
+        const path = StandardPaths.writableLocation(StandardPaths.AppDataLocation) + "/installed.json";
+
+        if (!fileIO.exists(path)) {
+            fileIO.write(path, '{ "installed": [] }');
+        }
+
+        const contents = fileIO.read(path)
+        if (!contents) {
+            throw new Error("Could not read contents!");
+        }
+
+        const items = JSON.parse(contents);
+
+        isInstalled = items.installed.some((game) => game.game_id == button.item.game_id);
+    }
+
+    Component.onCompleted: refreshInstalled()
+
+    Connections {
+        target: button.mainWindow
+        function onRefreshTriggerChanged() { button.refreshInstalled() }
+    }
+
     FileIO {
         id: fileIO
     }
@@ -43,27 +67,6 @@ Button {
             property real radius: 5
             property vector2d size: Qt.vector2d(gameImage.width, gameImage.height)
             property bool grayscale: !parent.isInstalled
-        }
-
-        Component.onCompleted: {
-            const path = StandardPaths.writableLocation(StandardPaths.AppDataLocation) + "/installed.json";
-
-            if (!fileIO.exists(path)) {
-                fileIO.write(path, '{ "installed": [] }');
-            }
-
-            const contents = fileIO.read(path)
-            if (!contents) {
-                throw new Error("Could not read contents!");
-            }
-
-            const items = JSON.parse(contents);
-
-            items.installed.forEach((item) => {
-                if (item.game_id == button.item.game_id) {
-                    button.isInstalled = true;
-                }
-            })
         }
     }
 


### PR DESCRIPTION
After removing a game, clicking its tile opens the launch dialog instead of the exe picker until restart. `removeGame()` updates installed.json and Main.qml emits `refreshTriggerChanged`, but nothing listens to it, each tile's `isInstalled` is only set once at startup.

Moved the installed.json check into a `refreshInstalled()` function and re-run it on `refreshTriggerChanged`.