### PR TITLE
Fix Windows build

### DIFF
--- a/src/cpp/GameLauncher.cpp
+++ b/src/cpp/GameLauncher.cpp
@@ -154,10 +154,10 @@ bool GameLauncher::LaunchThcrapThread(const QString &configPath, const QString &
     process.start();
     if (!process.waitForStarted()) {
         qCritical() << "[9L] Failed to start thcrap_loader!";
-        QByteArray stdout = process.readAllStandardOutput();
-        QByteArray stderr = process.readAllStandardError();
-        qDebug() << "stdout:" << stdout;
-        qDebug() << "stderr:" << stderr;
+        QByteArray stdOut = process.readAllStandardOutput();
+        QByteArray stdErr = process.readAllStandardError();
+        qDebug() << "stdout:" << stdOut;
+        qDebug() << "stderr:" << stdErr;
 
         launched = false;
         return false;


### PR DESCRIPTION
The Windows CI build has failed since 75a00fa: locals named `stdout`/`stderr` in GameLauncher.cpp are macros on the Windows CRT, so they don't compile there. Renamed to `stdOut`/`stdErr`.