### PR TITLE
Fix uninstalled game art not greying out on some graphics backends

### DIFF
--- a/src/qml/GameItem.qml
+++ b/src/qml/GameItem.qml
@@ -42,7 +42,7 @@ Button {
             fragmentShader: "/shaders/image_mask.frag.qsb"
             property real radius: 5
             property vector2d size: Qt.vector2d(gameImage.width, gameImage.height)
-            property bool grayscale: !parent.isInstalled
+            property real grayscale: button.isInstalled ? 0.0 : 1.0
         }
 
         Component.onCompleted: {

--- a/src/shaders/image_mask.frag
+++ b/src/shaders/image_mask.frag
@@ -10,7 +10,7 @@ layout(std140, binding = 0) uniform buf {
     float qt_Opacity;
     float radius;
     vec2 size;
-    bool grayscale;
+    float grayscale;
 };
 
 layout(binding = 1) uniform sampler2D source;
@@ -37,7 +37,7 @@ void main() {
     vec4 tex = texture(source, uv);
 
     float g = dot(tex.rgb, vec3(0.344, 0.5, 0.156));
-    vec3 color = mix(tex.rgb, vec3(g), float(grayscale));
+    vec3 color = mix(tex.rgb, vec3(g), grayscale);
 
     fragColor = vec4(color, tex.a) * qt_Opacity * inside;
 }


### PR DESCRIPTION
`bool` ShaderEffect uniforms don't work on all graphics backends (silently false on Linux/OpenGL here); `float` does.